### PR TITLE
Proper detail generation

### DIFF
--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -43,12 +43,20 @@ module Jekyll
         @bibtex_options ||= { :filter => :latex }
       end
 
+      def bibtex_options_raw
+        @bibtex_options_raw ||= { :strip => false }
+      end
+
       def bibtex_path
         @bibtex_path ||= extend_path(bibtex_file)
       end
 
       def bibliography
         @bibliography ||= BibTeX.open(bibtex_path, bibtex_options)
+      end
+      
+      def bibliography_raw
+        @bibliography_raw ||= BibTeX.open(bibtex_path, bibtex_options_raw)
       end
 
       def entries
@@ -58,9 +66,21 @@ module Jekyll
           b = b.sort_by { |e| e[config['sort_by']].to_s }
           b.reverse! if config['order'] =~ /^(desc|reverse)/i
         end
-
+        
         b
       end
+
+      def entries_raw
+        b = bibliography_raw[query || config['query']]
+
+        unless config['sort_by'] == 'none'
+          b = b.sort_by { |e| e[config['sort_by']].to_s }
+          b.reverse! if config['order'] =~ /^(desc|reverse)/i
+        end
+        
+        b
+      end
+
 
       def cited_only?
         !!@cited
@@ -132,7 +152,7 @@ module Jekyll
 
       def cite_details(key, text)
         if bibliography.key?(key)
-          link_to details_link_for(bibliography[key]), text || config['details_link']
+          link_to details_link_for(bibliography_raw[key]), text || config['details_link']
         else
           '(missing reference)'
         end


### PR DESCRIPTION
Hi

Thanks for maintaining this library.  Recently I came across a bug, and I would like to pay your attention to it.

When I generate details for an entry a couple of things go wrong:
1) In the bibtex field of the page 'entry' the latex-style symbols are converted to unicode.  The bibtex entry should be exactly the same as in my .bib file.  Otherwise bibtex (latex one) might not process unicode symbols correctly.
2) Multiple paragraphs in the abstract are lost due to replacement of newlines.  Which makes it more difficult to read and clumsy when you want to insert this entry in your bibtex file.

In essence that suggests that we need to keep the bibtex part of the details exactly as in the original file.  In order to do that one has to remove 'latex' filter, add ':strip => false' and apply 'latex' filter only when generating html.  That was my first attempt which unfortunately have failed -- when I convert an entry with a filter, bibtex-ruby fails with the error-message "Failed to load filter".  After some time I gave up on this idea and simply added a raw bibliography in utilities.rb adjusting details.rb accordingly.  This isn't the best solution, but it seems to work rather well.

Please have a look, may be you can come up with something more elegant.  It would be just nice to fix it somehow.

Cheers,
Artem.
