### PR TITLE
Details link available on bibliographic references template

### DIFF
--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -241,7 +241,8 @@ module Jekyll
           'key' => entry.key,
           'type' => entry.type.to_s,
           'link' => repository_link_for(entry),
-          'index' => index
+          'index' => index,
+          'details' => details_link_for(entry)
         })
       end
 


### PR DESCRIPTION
I'm using jekyll-scholar to generate my website and I'd like to have a link to each of my paper's details page. I want to write something like this on the template:

```
{{ reference }} <br/> <a href="{{ details }}">Details</a>
```

This small change makes it possible. I'm sharing the changes because possible more people might be interested in doing the same.

Thanks,
Luís
