### PR TITLE
Added the 'numbering' option in the configuration for unordered publicat...

### DIFF
--- a/lib/jekyll/scholar/defaults.rb
+++ b/lib/jekyll/scholar/defaults.rb
@@ -6,6 +6,8 @@ module Jekyll
 
       'sort_by'               => 'none',
       'order'                 => 'ascending',
+      'bibliography_list_tag' => 'ol',
+      'bibliography_item_tag' => 'li',
 
       'source'                => './_bibliography',
       'bibliography'          => 'references.bib',

--- a/lib/jekyll/scholar/tags/bibliography.rb
+++ b/lib/jekyll/scholar/tags/bibliography.rb
@@ -39,15 +39,11 @@ module Jekyll
               config['details_link'], :class => config['details_link_class'])
           end
 
-          content_tag :li, reference
+          content_tag config['bibliography_item_tag'], reference
         }.join("\n")
 
-        if config['numbering'] == false
-          content_tag :ul, bibliography, :class => config['bibliography_class']
-        else
-         content_tag :ol, bibliography, :class => config['bibliography_class']
-        end
-      
+        content_tag config['bibliography_list_tag'], bibliography, :class => config['bibliography_class']
+        
       end
     end
 


### PR DESCRIPTION
I thought it would be useful to have a configuration option for jekyll-scholar so that the publication list is not numbered. 
I modified the 'bibliography.rb' file so that, if the _config.yml file for the jekyll site has an option **numbering : false**, then the list will be unordered (_ul_), otherwise it will be the standard ordered (_ol_) list.

![_config_yml](https://cloud.githubusercontent.com/assets/430881/4811165/81d87362-5eb8-11e4-88ba-b710c16886e4.png)
