### PR TITLE
Details

### DIFF
--- a/features/details.feature
+++ b/features/details.feature
@@ -182,7 +182,7 @@ Feature: Details
     Then the _site directory should exist
     And I should see "pretty" in "_config.yml"
     And the "_site/scholar/index.html" file should exist
-    And I should see "<a[^>]+href=\"/bibliography/ruby/index.html\">" in "_site/scholar/index.html"
+    And I should see "<a[^>]+href=\"/bibliography/ruby/\">" in "_site/scholar/index.html"
     And the "_site/bibliography/ruby/index.html" file should exist
 
   @generators @parse_months

--- a/lib/jekyll/scholar/generators/details.rb
+++ b/lib/jekyll/scholar/generators/details.rb
@@ -15,7 +15,7 @@ module Jekyll
         process(@name)
         read_yaml(File.join(base, '_layouts'), config['details_layout'])
 
-        data['entry'] = liquidify(entry)
+        data.merge!(reference_data(entry))
       end
 
     end

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -323,7 +323,7 @@ module Jekyll
         name.gsub!(/[:\s]+/, '_')
 
         if site.config['permalink'] == 'pretty'
-          name << '/index.html'
+          name << '/'
         else
           name << '.html'
         end

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -272,16 +272,22 @@ module Jekyll
       def bibliography_tag(entry, index)
         return missing_reference unless entry
 
-        liquid_template.render({
+        liquid_template.render(
+          reference_data(entry,index).merge({
+            'index' => index,
+            'details' => details_link_for(entry)
+        }))
+      end
+
+      def reference_data(entry, index = nil)
+        {
           'entry' => liquidify(entry),
           'reference' => reference_tag(entry, index),
           'key' => entry.key,
           'type' => entry.type.to_s,
           'link' => repository_link_for(entry),
-          'links' => repository_links_for(entry),
-          'index' => index,
-          'details' => details_link_for(entry)
-        })
+          'links' => repository_links_for(entry)
+        }
       end
 
       def liquidify(entry)


### PR DESCRIPTION
I just switched over my website to Jekyll with Scholar, and I like it a lot. When creating detailed pages for my publications, I wanted to use some information that was not exposed. I've made a few small changes, that I think could benefit more people.
* If `permalink: pretty` is set, link only to the folder, without appending `index.html`. Since it will be added implicitly, this looks nicer.
* Expose some of the extra information you have available in the bibentry also to the details page. Specifically, the formatted key and reference, and the links.