### PR TITLE
Add global option to allow for raw bibtex entries in the reference blocks and cite_detail pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ default configuration is as follows:
 
       replace_strings: true
       join_strings:    true
+      
+      use_raw_bibtex_entry: false
 
       details_dir:    bibliography
       details_layout: bibtex.html
@@ -76,6 +78,10 @@ The `source` option indicates where your bibliographies are stored;
 `bibliography` is the name of your default bibliography. For best results,
 please ensure that your Bibliography is encoded as ASCII or UTF-8.
 
+The `use_raw_bibtex_entry` option will disable parsing of Liquid tags that 
+are embedded in the Bibtex fields. This option provides a way to circumvent 
+the problem that the double braces functionality of BibTex is accidentally 
+parsed by Liquid, while it was intended to keep the exact capitalization style.
 
 ### Bibliographies
 

--- a/features/bibtex.feature
+++ b/features/bibtex.feature
@@ -276,6 +276,7 @@ Feature: BibTeX
     Given I have a scholar configuration with:
       | key                   | value              |
       | bibliography_template | "{{entry.bibtex}}" |
+      | use_raw_bibtex_entry  | true               |
     And I have a "_bibliography" directory
     And I have a file "_bibliography/references.bib":
       """
@@ -287,7 +288,7 @@ Feature: BibTeX
       """
       ---
       ---
-      {% bibliography -f references --raw_bibtex %}
+      {% bibliography -f references %}
       """
     When I run jekyll
     Then the _site directory should exist

--- a/features/cite_details.feature
+++ b/features/cite_details.feature
@@ -41,7 +41,7 @@ Feature: Citations
     And I have a file "_bibliography/references.bib":
       """
       @book{a,
-        title     = {{"b" | prepend: "a"}}
+        title     = {{'b' | prepend: 'a'}}
       }
       """
     And I have a "_layouts" directory  
@@ -50,12 +50,12 @@ Feature: Citations
       ---
       ---
       {{ page.entry.bibtex }}
-      """      
+      """
     When I run jekyll
     Then the _site directory should exist
     
     And the "_site/bibliography/a.html" file should exist
-    And I should see """{{"b" prepend: "a"}}""" in "_site/bibliography/a.html"
+    And I should see "{{'b' | prepend: 'a'}}" in "_site/bibliography/a.html"
     And I should not see "ab" in "_site/bibliography/a.html"
     
   @tags @bibliography @config @template @cite_details
@@ -69,7 +69,7 @@ Feature: Citations
     And I have a file "_bibliography/references.bib":
       """
       @book{a,
-        title     = {{"b" | prepend: "a"}}
+        title     = {{'b' | prepend: 'a'}}
       }
       """
     And I have a "_layouts" directory  
@@ -83,7 +83,7 @@ Feature: Citations
     Then the _site directory should exist
     
     And the "_site/bibliography/a.html" file should exist
-    And I should not see """{{"b" prepend: "a"}}""" in "_site/bibliography/a.html"
+    And I should not see "{{'b' | prepend: 'a'}}" in "_site/bibliography/a.html"
     And I should see "ab" in "_site/bibliography/a.html"
     
   @tags @cite_details

--- a/features/cite_details.feature
+++ b/features/cite_details.feature
@@ -29,6 +29,63 @@ Feature: Citations
     And the "_site/scholar.html" file should exist
     And I should see "Details</a>" in "_site/scholar.html"
 
+  @tags @bibliography @config @template @cite_details
+  Scenario: Raw bibtex template in details page
+    Given I have a scholar configuration with:
+      | key                   | value            |
+      | source                | ./_bibliography  |
+      | bibliography_template | {{entry.bibtex}} |
+      | details_layout        | details.html     |
+      | use_raw_bibtex_entry  | true             |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{a,
+        title     = {{"b" | prepend: "a"}}
+      }
+      """
+    And I have a "_layouts" directory  
+    And I have a file "_layouts/details.html":
+      """
+      ---
+      ---
+      {{ page.entry.bibtex }}
+      """      
+    When I run jekyll
+    Then the _site directory should exist
+    
+    And the "_site/bibliography/a.html" file should exist
+    And I should see """{{"b" prepend: "a"}}""" in "_site/bibliography/a.html"
+    And I should not see "ab" in "_site/bibliography/a.html"
+    
+  @tags @bibliography @config @template @cite_details
+  Scenario: Raw bibtex template in details page
+    Given I have a scholar configuration with:
+      | key                   | value            |
+      | source                | ./_bibliography  |
+      | bibliography_template | {{entry.bibtex}} |
+      | details_layout        | details.html     |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{a,
+        title     = {{"b" | prepend: "a"}}
+      }
+      """
+    And I have a "_layouts" directory  
+    And I have a file "_layouts/details.html":
+      """
+      ---
+      ---
+      {{ page.entry.bibtex }}
+      """      
+    When I run jekyll
+    Then the _site directory should exist
+    
+    And the "_site/bibliography/a.html" file should exist
+    And I should not see """{{"b" prepend: "a"}}""" in "_site/bibliography/a.html"
+    And I should see "ab" in "_site/bibliography/a.html"
+    
   @tags @cite_details
   Scenario: A Simple Cite Details Link With A Text Argument
     Given I have a scholar configuration with:

--- a/lib/jekyll/scholar/defaults.rb
+++ b/lib/jekyll/scholar/defaults.rb
@@ -23,6 +23,7 @@ module Jekyll
       'details_dir'           => 'bibliography',
       'details_layout'        => 'bibtex.html',
       'details_link'          => 'Details',
+      'use_raw_bibtex_entry'  => false,
 
       'bibliography_class'    => 'bibliography',
       'bibliography_template' => '{{reference}}',

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -80,13 +80,9 @@ module Jekyll
           opts.on('-T', '--template TEMPLATE') do |template|
             @bibliography_template = template
           end
-
-          opts.on('-R', '--raw_bibtex') do |raw_bibtex|
-            @raw_bibtex = raw_bibtex
-          end
         end
 
-        argv = arguments.split(/(\B-[cCfqptTslomAR]|\B--(?:cited(_in_order)?|file|query|prefix|text|style|template|locator|offset|max|suppress_author|raw_bibtex|))/)
+        argv = arguments.split(/(\B-[cCfqptTslomA]|\B--(?:cited(_in_order)?|file|query|prefix|text|style|template|locator|offset|max|suppress_author|))/)
 
         parser.parse argv.map(&:strip).reject(&:empty?)
       end
@@ -182,7 +178,7 @@ module Jekyll
       end
 
       def raw_bibtex?
-        !!@raw_bibtex
+        config['use_raw_bibtex_entry']
       end
 
       def repository?


### PR DESCRIPTION
This merge request solves #117. 

The naming of the global option is just a suggestion; I don't know if it follows the guidelines properly.