### PR TITLE
Improve sorting and support grouping for bibliographies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ default configuration is as follows:
       sort_by: none
       order: ascending
 
+      group_by: none
+      group_order: ascending
+
       source: ./_bibliography
       bibliography: references.bib
       bibliography_template: "{{reference}}"
@@ -170,7 +173,8 @@ use the `--max` option:
     {% bibliography --max 5 %}
 
 This would generate a bibliography containing only the first 5 entries
-of your bibliography (after query filters and sort options have been applied).
+of your bibliography (after query filters and sort options have been
+applied). Limiting entries is disabled if grouping is active.
 
 ### Bibliography Template
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,33 @@ are embedded in the Bibtex fields. This option provides a way to circumvent
 the problem that the double braces functionality of BibTex is accidentally 
 parsed by Liquid, while it was intended to keep the exact capitalization style.
 
+The `sort_by` and `order` options specify if and how bibliography
+entries are sorted. Entries can be sorted on multiple fields, by using
+a list of keys, e.g. `sort_by: year,month`. Ordering can be specified
+per sort level, e.g. `order: descending,ascending` will sort the years
+descending, but per year the months are ascending. If there are more
+sort keys than order directives, the last order entry is used for the
+remaining keys.
+
+The `group_by` and `group_order` options specify how bibliography
+items are grouped. Grouping can be multi-level as well,
+e.g. `group_by: type, year` groups entries per publication type, and
+within those groups per year. Ordering for groups is specified in the
+same way as the sort order. Publication types -- specified with group
+key `type`, can be ordered by adding `type_order` to the
+configuration. For example, `type_order: article,techreport` lists
+journal articles before technical reports. Types not mentioned in
+`type_order` are considered smaller than types that are
+mentioned. Types can be merge in one group using the `type_aliases`
+setting. By default `phdthesis` and `mastersthesis` are grouped as
+`thesis`. By using, for example, `type_aliases: { inproceeding =>
+article}`, journal and conference articles appear in a single
+group. The display names for entry types are specified with
+`type_names`. Names for common types are provided, but they can be
+extended or overridden. For example, the default name for `article` is
+*Journal Articles*, but it can be changed to *Papers* using
+`type_name: { article => 'Papers' }`.
+
 ### Bibliographies
 
 Once you have loaded Jekyll-Scholar, all files with the extension `.bib` or

--- a/features/grouping.feature
+++ b/features/grouping.feature
@@ -1,0 +1,276 @@
+Feature: Grouping BibTeX Bibliographies
+  As a scholar who likes to blog
+  I want to group my bibliographies according to configurable parameters
+
+  @tags @grouping
+  Scenario: Group By Year
+    Given I have a scholar configuration with:
+      | key      | value             |
+      | group_by | year              |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby1,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      @book{ruby2,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2007},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then I should see "<h2 class=\"bibliography\">2007</h2>" in "_site/scholar.html"
+    And I should see "<h2 class=\"bibliography\">2008</h2>" in "_site/scholar.html"
+
+  @tags @grouping
+  Scenario: Group Order
+    Given I have a scholar configuration with:
+      | key         | value             |
+      | group_by    | year              |
+      | group_order | ascending         | 
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby1,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      @book{ruby2,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2007},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then "<h2 class=\"bibliography\">2007</h2>" should come before "<h2 class=\"bibliography\">2008</h2>" in "_site/scholar.html"
+
+  @tags @grouping
+  Scenario: Reverse Group Order
+    Given I have a scholar configuration with:
+      | key         | value             |
+      | group_by    | year              |
+      | group_order | descending        | 
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby1,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      @book{ruby2,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2007},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then "<h2 class=\"bibliography\">2008</h2>" should come before "<h2 class=\"bibliography\">2007</h2>" in "_site/scholar.html"
+
+  @tags @grouping
+  Scenario: Multi-level Group Order
+    Given I have a scholar configuration with:
+      | key         | value                |
+      | group_by    | year,month           |
+      | group_order | descending,ascending | 
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby1,
+        title     = {November 08},
+        year      = {2008},
+        month     = {nov}
+      }
+      @book{ruby2,
+        title     = {March 08},
+        year      = {2008},
+        month     = {mar}
+      }
+      @book{ruby3,
+        title     = {June 07},
+        year      = {2007},
+        month     = {jun}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then "March" should come before "November" in "_site/scholar.html"
+    And "November" should come before "June" in "_site/scholar.html"
+
+  @tags @grouping
+  Scenario: Group by Type
+    Given I have a scholar configuration with:
+      | key         | value                |
+      | group_by    | type                 |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby1,
+        title     = {Book 1},
+      }
+      @article{ruby2,
+        title     = {Article 1},
+      }
+      @book{ruby3,
+        title     = {Book 2},
+      }
+      @article{ruby4,
+        title     = {Article 2},
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then "Journal Articles" should come before "Article 1" in "_site/scholar.html"
+    And "Journal Articles" should come before "Article 2" in "_site/scholar.html"
+    Then "Books" should come before "Book 1" in "_site/scholar.html"
+    And "Books" should come before "Book 2" in "_site/scholar.html"
+
+  @tags @grouping
+  Scenario: Type Order
+    Given I have a scholar configuration with:
+      | key         | value                |
+      | group_by    | type                 |
+      | type_order  | [article,book]       |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby1,
+        title     = {Book 1},
+      }
+      @article{ruby2,
+        title     = {Article 1},
+      }
+      @book{ruby3,
+        title     = {Book 2},
+      }
+      @techreport{ruby4,
+        title     = {Book 2},
+      }
+      @article{ruby5,
+        title     = {Article 2},
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then "Journal Articles" should come before "Books" in "_site/scholar.html"
+    And "Books" should come before "Technical Reports" in "_site/scholar.html"
+
+  @tags @grouping
+  Scenario: Type Names
+    Given I have a scholar configuration with:
+      | key         | value                      |
+      | group_by    | type                       |
+      | type_names  | { article: 'Long Papers' } |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @article{ruby1,
+        title     = {Article},
+      }
+      @book{ruby2,
+        title     = {Book},
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then I should see "Long Papers" in "_site/scholar.html"
+    And I should not see "Journal Articles" in "_site/scholar.html"
+    And I should see "Books" in "_site/scholar.html"
+
+  @tags @grouping
+  Scenario: Month Names
+    Given I have a scholar configuration with:
+      | key         | value                                                                                |
+      | group_by    | month                                                                                |
+      | month_names | [Januar,Februar,März,April,Mai,Juni,Juli,August,September,Oktober,November,Dezember] |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby1,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        month     = jan
+      }
+      @book{ruby2,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        month     = dec
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then I should see "Januar" in "_site/scholar.html"
+    And I should not see "January" in "_site/scholar.html"
+    And I should see "Dezember" in "_site/scholar.html"
+    And I should not see "December" in "_site/scholar.html"

--- a/features/grouping.feature
+++ b/features/grouping.feature
@@ -240,6 +240,34 @@ Feature: Grouping BibTeX Bibliographies
     And I should see "Books" in "_site/scholar.html"
 
   @tags @grouping
+  Scenario: Type Aliases
+    Given I have a scholar configuration with:
+      | key          | value                    |
+      | group_by     | type                     |
+      | type_aliases | { phdthesis: phdthesis } |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @mastersthesis{ruby1,
+        title     = {MSc Thesis},
+      }
+      @phdthesis{ruby2,
+        title     = {PhD Thesis},
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then I should see "PhD Theses" in "_site/scholar.html"
+    And I should not see "Master's Theses" in "_site/scholar.html"
+
+  @tags @grouping
   Scenario: Month Names
     Given I have a scholar configuration with:
       | key         | value                                                                                |

--- a/features/sorting.feature
+++ b/features/sorting.feature
@@ -262,3 +262,40 @@ Feature: Sorting BibTeX Bibliographies
     And the "_site/scholar.html" file should exist
     Then "August 07" should come before "March 08" in "_site/scholar.html"
     And "March 08" should come before "December 08" in "_site/scholar.html"
+
+  @tags @sorting
+  Scenario: Multi-level Sort Order
+    Given I have a scholar configuration with:
+      | key     | value                 |
+      | sort_by | year, month           |
+      | order   | descending, ascending |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby1,
+        title     = {August 07},
+        year      = {2007},
+        month     = aug
+      }
+      @book{ruby2,
+        title     = {March 08},
+        year      = {2008},
+        month     = mar
+      }
+      @book{ruby3,
+        title     = {December 08},
+        year      = {2008},
+        month     = dec
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then "March 08" should come before "December 08" in "_site/scholar.html"
+    And "December 08" should come before "August 07" in "_site/scholar.html"

--- a/lib/jekyll/scholar/defaults.rb
+++ b/lib/jekyll/scholar/defaults.rb
@@ -1,39 +1,59 @@
 module Jekyll
   class Scholar
     @defaults = {
-      'style'                 => 'apa',
-      'locale'                => 'en',
+      'style'                  => 'apa',
+      'locale'                 => 'en',
 
-      'sort_by'               => 'none',
-      'order'                 => 'ascending',
-      'bibliography_list_tag' => 'ol',
-      'bibliography_item_tag' => 'li',
+      'sort_by'                => 'none',
+      'order'                  => 'ascending',
+      'group_by'               => 'none',
+      'group_order'            => 'ascending',
+      'bibliography_group_tag' => 'h2,h3,h4,h5',
+      'bibliography_list_tag'  => 'ol',
+      'bibliography_item_tag'  => 'li',
 
-      'source'                => './_bibliography',
-      'bibliography'          => 'references.bib',
-      'repository'            => nil,
+      'source'                 => './_bibliography',
+      'bibliography'           => 'references.bib',
+      'repository'             => nil,
 
-      'bibtex_options'        => { :strip => false, :parse_months => true },
-      'bibtex_filters'        => [ :latex ],
-      'bibtex_skip_fields'    => [ :abstract, :month_numeric ],
+      'bibtex_options'         => { :strip => false, :parse_months => true },
+      'bibtex_filters'         => [ :latex ],
+      'bibtex_skip_fields'     => [ :abstract, :month_numeric ],
 
-      'replace_strings'       => true,
-      'join_strings'          => true,
+      'replace_strings'        => true,
+      'join_strings'           => true,
 
-      'details_dir'           => 'bibliography',
-      'details_layout'        => 'bibtex.html',
-      'details_link'          => 'Details',
-      'use_raw_bibtex_entry'  => false,
+      'details_dir'            => 'bibliography',
+      'details_layout'         => 'bibtex.html',
+      'details_link'           => 'Details',
+      'use_raw_bibtex_entry'   => false,
 
-      'bibliography_class'    => 'bibliography',
-      'bibliography_template' => '{{reference}}',
+      'bibliography_class'     => 'bibliography',
+      'bibliography_template'  => '{{reference}}',
 
-      'reference_tagname'     => 'span',
-      'missing_reference'     => '(missing reference)',
+      'reference_tagname'      => 'span',
+      'missing_reference'      => '(missing reference)',
 
-      'details_link_class'    => 'details',
+      'details_link_class'     => 'details',
 
-      'query'                 => '@*'
+      'query'                  => '@*',
+
+      'type_names' => {
+        'article' => 'Journal Articles',
+        'book' => 'Books',
+        'incollection' => 'Book Chapters',
+        'inproceedings' => 'Conference Articles',
+        'thesis' => 'Theses',
+        'manual' => 'Manuals',
+        'techreport' => 'Technical Reports',
+        'misc' => 'Miscellaneous',
+        'unpublished' => 'Unpublished',
+      },
+      'type_aliases' => {
+        'phdthesis' => 'thesis',
+        'mastersthesis' => 'thesis',
+      },
+      'type_order' => [],
 
     }.freeze
 

--- a/lib/jekyll/scholar/defaults.rb
+++ b/lib/jekyll/scholar/defaults.rb
@@ -55,6 +55,7 @@ module Jekyll
       },
       'type_order' => [],
 
+      'month_names' => nil,
     }.freeze
 
     class << self

--- a/lib/jekyll/scholar/defaults.rb
+++ b/lib/jekyll/scholar/defaults.rb
@@ -44,6 +44,8 @@ module Jekyll
         'incollection' => 'Book Chapters',
         'inproceedings' => 'Conference Articles',
         'thesis' => 'Theses',
+        'mastersthesis' => 'Master\'s Theses',
+        'phdthesis' => 'PhD Theses',
         'manual' => 'Manuals',
         'techreport' => 'Technical Reports',
         'misc' => 'Miscellaneous',

--- a/lib/jekyll/scholar/tags/bibliography.rb
+++ b/lib/jekyll/scholar/tags/bibliography.rb
@@ -61,11 +61,10 @@ module Jekyll
           else
             groupsOrItems
               .map do |keyvalue,value|
-                bibhead = content_tag(tags.first,
+                bibhead = content_tag(tags.first || group_tags.last,
                                       group_name(keys.first, keyvalue),
                                       :class => config['bibliography_class'])
-                bibentries = group_renderer(value, keys.drop(1),
-                                      tags.length > 1 ? tags.drop(1) : tags)
+                bibentries = group_renderer(value, keys.drop(1), tags.drop(1))
                 bibhead + "\n" + bibentries
               end
               .join("\n")

--- a/lib/jekyll/scholar/tags/bibliography.rb
+++ b/lib/jekyll/scholar/tags/bibliography.rb
@@ -42,8 +42,39 @@ module Jekyll
           cited_keys.clear
         end
 
-        items = items[offset..max] if limit_entries?
+        if group?
+          groups = group(items)
+          bibliography = render_groups(groups)
+        else
+          items = items[offset..max] if limit_entries?
+          bibliography = render_items(items)
+        end
 
+        bibliography
+      end
+
+      def render_groups(groups)
+        def group_renderer(groupsOrItems,keys,tags)
+          if keys.count == 0
+            renderer(force = true)
+            render_items(groupsOrItems)
+          else
+            groupsOrItems
+              .map do |keyvalue,value|
+                bibhead = content_tag(tags.first,
+                                      group_name(keys.first, keyvalue),
+                                      :class => config['bibliography_class'])
+                bibentries = group_renderer(value, keys.drop(1),
+                                      tags.length > 1 ? tags.drop(1) : tags)
+                bibhead + "\n" + bibentries
+              end
+              .join("\n")
+          end
+        end
+        group_renderer(groups,group_keys,group_tags)
+      end
+      
+      def render_items(items)
         bibliography = items.each_with_index.map { |entry, index|
           reference = bibliography_tag(entry, index + 1)
 
@@ -56,8 +87,8 @@ module Jekyll
         }.join("\n")
 
         content_tag config['bibliography_list_tag'], bibliography, :class => config['bibliography_class']
-
       end
+      
     end
 
   end

--- a/lib/jekyll/scholar/tags/bibliography.rb
+++ b/lib/jekyll/scholar/tags/bibliography.rb
@@ -54,23 +54,30 @@ module Jekyll
       end
 
       def render_groups(groups)
-        def group_renderer(groupsOrItems,keys,tags)
+        def group_renderer(groupsOrItems,keys,order,tags)
           if keys.count == 0
             renderer(force = true)
             render_items(groupsOrItems)
           else
             groupsOrItems
-              .map do |keyvalue,value|
+              .sort do |e1,e2|
+                if (order.first || group_order.last) =~ /^(desc|reverse)/i
+                  group_compare(keys.first,e2[0],e1[0])
+                else
+                  group_compare(keys.first,e1[0],e2[0])
+                end
+              end
+              .map do |e|
                 bibhead = content_tag(tags.first || group_tags.last,
-                                      group_name(keys.first, keyvalue),
+                                      group_name(keys.first, e[0]),
                                       :class => config['bibliography_class'])
-                bibentries = group_renderer(value, keys.drop(1), tags.drop(1))
+                bibentries = group_renderer(e[1], keys.drop(1), order.drop(1), tags.drop(1))
                 bibhead + "\n" + bibentries
               end
               .join("\n")
           end
         end
-        group_renderer(groups,group_keys,group_tags)
+        group_renderer(groups,group_keys,group_order,group_tags)
       end
       
       def render_items(items)

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -282,7 +282,7 @@ module Jekyll
         end
       end
       
-      def month_name(month):
+      def month_name(month)
         case month
         when 1
           'January'
@@ -311,6 +311,7 @@ module Jekyll
         else
           'Unknown'
         end
+      end
 
       def suppress_author?
         !!@suppress_author

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -276,39 +276,42 @@ module Jekyll
         when 'type'
           config['type_names'][value] || value.to_s
         when 'month_numeric'
-          case value
-          when 1
-            'January'
-          when 2
-            'February'
-          when 3
-            'March'
-          when 4
-            'April'
-          when 5
-            'May'
-          when 6
-            'June'
-          when 7
-            'July'
-          when 8
-            'August'
-          when 9
-            'September'
-          when 10
-            'October'
-          when 11
-            'November'
-          when 12
-            'December'
-          else
-            'Unknown'
-          end
+          month_name(value)
         else
           value.to_s
         end
       end
       
+      def month_name(month):
+        case month
+        when 1
+          'January'
+        when 2
+          'February'
+        when 3
+          'March'
+        when 4
+          'April'
+        when 5
+          'May'
+        when 6
+          'June'
+        when 7
+          'July'
+        when 8
+          'August'
+        when 9
+          'September'
+        when 10
+          'October'
+        when 11
+          'November'
+        when 12
+          'December'
+        else
+          'Unknown'
+        end
+
       def suppress_author?
         !!@suppress_author
       end

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -201,14 +201,6 @@ module Jekyll
             .group_by do |item|
               group_value(keys.first,item)
             end
-            .sort do |e1, e2|
-              if (order.first || group_order.last) =~ /^(desc|reverse)/i
-                group_compare(keys.first,e2[0],e1[0])
-              else
-                group_compare(keys.first,e1[0],e2[0])
-              end
-            end
-            .to_h
           if keys.count == 1
             groups
           else

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -202,7 +202,7 @@ module Jekyll
               group_value(keys.first,item)
             end
             .sort do |e1, e2|
-              if order.first =~ /^(desc|reverse)/i
+              if (order.first || group_order.last) =~ /^(desc|reverse)/i
                 group_compare(keys.first,e2[0],e1[0])
               else
                 group_compare(keys.first,e1[0],e2[0])
@@ -213,7 +213,7 @@ module Jekyll
             groups
           else
             groups.merge(groups) do |key,items|
-              grouper(items,keys.drop(1), order.length > 1 ? order.drop(1) : order)
+              grouper(items,keys.drop(1),order.drop(1))
             end
           end
         end
@@ -259,7 +259,7 @@ module Jekyll
       def group_value(key,item)
         case key
         when 'type'
-          config['type_aliases'][item.type.to_s] || item.type.to_s
+          type_aliases[item.type.to_s] || item.type.to_s
         else
           value = item[key]
           if value.numeric?
@@ -293,6 +293,10 @@ module Jekyll
 
       def type_order
         @type_order ||= config['type_order']
+      end
+
+      def type_aliases
+        @type_aliases ||= Scholar.defaults['type_aliases'].merge(config['type_aliases'])
       end
 
       def type_names


### PR DESCRIPTION
This pull request introduces improved sorting and support for grouping of bibliographies. I use it myself for a list of publication, which is otherwise very messy. I'm happy to discuss and improve the code, if you feel this is necessary. The `jekyll-scholar-extras` also provide support for grouping, but it introduces an extra dependency, and one that is not easily availble (not in the standard gem repository). I think having this in `jekyll-scholar` itself can be a nice feature.

It includes the following changes:
 * Sort `order` can be mulitlevel, i.e. `order: descending,ascending` will sort the first sort key ascending, and the second sort key descending. If there are more sort keys than order directives, the last item in `order` is used for the remaining keys.
 * Introduce `group_by` and `group_order` settings, to allow grouping of bibliography items.
   * Special care is taken to render proper names for entry `type`s and `month`s. The names for entry types can be customized using the `type_names` setting.
   * Ordering `group_order` is multi-level, just as for sorting.
   * Entry types have no inherit ordering, but one can be specified using `type_order`. Entry types can be merged using `type_aliases`, by default PhD and Master theses are treated as one entry type for grouping.
   * Because the CiteProc renderer sometimes gives different output depending on the previous entry -- e.g. not listing authors of they are the same -- a new instance is created for every group.
   * Limiting entries is disabled when grouping is active.