### PR TITLE
added method for link target, with a new tag and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,12 @@ a specific page. As an example, the tag
 will attempt to read the key `ruby` from file `/home/foo/bar.bib`. It will not
 fallback to the default BibTeX file.
 
+<!-- elotroalex edit: added documentation for changes -->
+#### Citation pointing to another page in your site
+In some cases, you might want your citation to link to another page on your cite (ex. a separate works cited page). As a solution, Jekyll-Scholar provides the `--relative` tag. For example, if you wanted the link to point to an ID in a bibliography.html page, you would use:
+
+    {% cite ruby --relative bibliography.html %}
+
 #### Multiple bibliographies within one document (like [multibib.sty](http://www.ctan.org/pkg/multibib))
 
 When you have multiple `{% bibliography %}` sections in one file,

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -93,7 +93,7 @@ module Jekyll
           end
         end
 
-        argv = arguments.split(/(\B-[cCfqptTslomA]|\B--(?:cited(_in_order)?|file|query|prefix|text|style|template|locator|offset|max|suppress_author|))/)
+        argv = arguments.split(/(\B-[cCfqptTslomA]|\B--(?:cited(_in_order)?|file|query|relative|prefix|text|style|template|locator|offset|max|suppress_author|))/)
 
         parser.parse argv.map(&:strip).reject(&:empty?)
       end

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -17,7 +17,6 @@ module Jekyll
     # #site readers
     module Utilities
 
-    #elotroalex edit: added local variable relative  
 
       attr_reader :config, :site, :context, :prefix, :text, :offset, :max, :relative
 
@@ -62,8 +61,6 @@ module Jekyll
             @prefix = prefix
           end
 
-    # elotroalex edit: added flag for relative url for link_to
-
           opts.on('-r', '--relative RELATIVE') do |relative|
             @relative = relative
           end             
@@ -93,7 +90,7 @@ module Jekyll
           end
         end
 
-        argv = arguments.split(/(\B-[cCfqptTslomA]|\B--(?:cited(_in_order)?|file|query|relative|prefix|text|style|template|locator|offset|max|suppress_author|))/)
+        argv = arguments.split(/(\B-[cCfqrptTslomA]|\B--(?:cited(_in_order)?|file|query|relative|prefix|text|style|template|locator|offset|max|suppress_author|))/)
 
         parser.parse argv.map(&:strip).reject(&:empty?)
       end
@@ -576,8 +573,6 @@ module Jekyll
       def citation_number(key)
         (context['citation_numbers'] ||= {})[key] ||= cited_keys.length
       end
-
-    # #elotroalex edit: Added new method to control href output for cite  
 
       def link_target_for key
         "#{relative}##{[prefix, key].compact.join('-')}"

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -17,7 +17,11 @@ module Jekyll
     # #site readers
     module Utilities
 
-      attr_reader :config, :site, :context, :prefix, :text, :offset, :max
+    #elotroalex edit: added local variable relative  
+
+      attr_reader :config, :site, :context, :prefix, :text, :offset, :max, :relative
+
+
 
       def split_arguments(arguments)
 
@@ -52,11 +56,17 @@ module Jekyll
 
           opts.on('-q', '--query QUERY') do |query|
             @query = query
-          end
+          end       
 
           opts.on('-p', '--prefix PREFIX') do |prefix|
             @prefix = prefix
           end
+
+    # elotroalex edit: added flag for relative url for link_to
+
+          opts.on('-r', '--relative RELATIVE') do |relative|
+            @relative = relative
+          end             
 
           opts.on('-t', '--text TEXT') do |text|
             @text = text
@@ -567,6 +577,12 @@ module Jekyll
         (context['citation_numbers'] ||= {})[key] ||= cited_keys.length
       end
 
+    # #elotroalex edit: Added new method to control href output for cite  
+
+      def link_target_for key
+        "#{relative}##{[prefix, key].compact.join('-')}"
+      end
+
       def cite(keys)
         items = keys.map do |key|
           if bibliography.key?(key)
@@ -577,7 +593,7 @@ module Jekyll
           end
         end
 
-        link_to "##{[prefix, keys[0]].compact.join('-')}", render_citation(items)
+        link_to link_target_for(keys[0]), render_citation(items)
       end
 
       def cite_details(key, text)


### PR DESCRIPTION
I implemented your idea with an addition. I added a new tag `--relative` that allows the user to define what the relative path to the citation link is on a one by one case. A user can override this on the `utilities.rb` of course to implement your first solution. Everything is working like a charm on my set-up. Let me know if it didn't break anything.