### PR TITLE
added base_url and stripped trailing whitespaces from -r value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ demo
 .bundle
 coverage
 .ruby-version
+.DS_Store

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -575,7 +575,7 @@ module Jekyll
       end
 
       def link_target_for key
-        "#{base_url}#{relative}##{[prefix, key].compact.join('-')}"
+        "#{base_url}#{relative.to_s.strip}##{[prefix, key].compact.join('-')}"
       end
 
       def cite(keys)

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -575,7 +575,7 @@ module Jekyll
       end
 
       def link_target_for key
-        "#{base_url}#{relative.strip}##{[prefix, key].compact.join('-')}"
+        "#{base_url}#{relative}##{[prefix, key].compact.join('-')}"
       end
 
       def cite(keys)

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -575,7 +575,7 @@ module Jekyll
       end
 
       def link_target_for key
-        "#{relative}##{[prefix, key].compact.join('-')}"
+        "#{base_url}#{relative.strip}##{[prefix, key].compact.join('-')}"
       end
 
       def cite(keys)


### PR DESCRIPTION
Dear Sylvester,

I noticed a small flaw in the solution when I went to deploy to github pages. For those like me that work with different base_url's depending on my env, the links break when you move from one env to another. In any case, this patch takes care of that. On a related note, I'm going to start distributing Ed among friends tomorrow. I think the alpha is ready to start sharing. You can see [it in action here](http://elotroalex.github.io/ed/). The new `--relative` feature turned out to be even more of a blessing. I realized while designing the site that the footnotes could not co-exist peacefully with a references section in the bottom, so the separation of the references to a separate page solves that problem too. 