### PR TITLE
Added --group_by option for bibliography tag

### DIFF
--- a/features/grouping.feature
+++ b/features/grouping.feature
@@ -302,3 +302,67 @@ Feature: Grouping BibTeX Bibliographies
     And I should not see "January" in "_site/scholar.html"
     And I should see "Dezember" in "_site/scholar.html"
     And I should not see "December" in "_site/scholar.html"
+
+  @tags @grouping
+  Scenario: Local grouping override - no grouping
+    Given I have a scholar configuration with:
+      | group_by    | year
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby1,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      @book{ruby2,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2007},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references --group_by none %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then I should not see "<h2 class=\"bibliography\">2007</h2>" in "_site/scholar.html"
+    And I should not see "<h2 class=\"bibliography\">2008</h2>" in "_site/scholar.html"
+
+  @tags @grouping
+  Scenario: Local grouping override - grouping by year
+    Given I have a scholar configuration with:
+      | group_by    | none
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby1,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      @book{ruby2,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2007},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references --group_by none %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    Then I should see "<h2 class=\"bibliography\">2007</h2>" in "_site/scholar.html"
+    And I should see "<h2 class=\"bibliography\">2008</h2>" in "_site/scholar.html"

--- a/features/grouping.feature
+++ b/features/grouping.feature
@@ -306,7 +306,7 @@ Feature: Grouping BibTeX Bibliographies
   @tags @grouping
   Scenario: Local grouping override - no grouping
     Given I have a scholar configuration with:
-      | group_by    | year
+      | group_by    | year |
     And I have a "_bibliography" directory
     And I have a file "_bibliography/references.bib":
       """
@@ -338,7 +338,7 @@ Feature: Grouping BibTeX Bibliographies
   @tags @grouping
   Scenario: Local grouping override - grouping by year
     Given I have a scholar configuration with:
-      | group_by    | none
+      | group_by    | none |
     And I have a "_bibliography" directory
     And I have a file "_bibliography/references.bib":
       """

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -18,7 +18,7 @@ module Jekyll
     module Utilities
 
 
-      attr_reader :config, :site, :context, :prefix, :text, :offset, :max, :relative
+      attr_reader :config, :site, :context, :prefix, :text, :offset, :max, :relative, :group_by
 
 
 
@@ -85,12 +85,16 @@ module Jekyll
             @style = style
           end
 
+          opts.on('-g', '--group_by GROUP') do |group_by|
+            @group_by = group_by
+          end
+
           opts.on('-T', '--template TEMPLATE') do |template|
             @bibliography_template = template
           end
         end
 
-        argv = arguments.split(/(\B-[cCfqrptTslomA]|\B--(?:cited(_in_order)?|file|query|relative|prefix|text|style|template|locator|offset|max|suppress_author|))/)
+        argv = arguments.split(/(\B-[cCfqrptTsglomA]|\B--(?:cited(_in_order)?|file|query|relative|prefix|text|style|group_by|template|locator|offset|max|suppress_author|))/)
 
         parser.parse argv.map(&:strip).reject(&:empty?)
       end
@@ -199,7 +203,7 @@ module Jekyll
       end
 
       def group?
-        config['group_by'] != 'none'
+        (group_by.nil? && config['group_by'] != 'none') || (!group_by.nil? && group_by != 'none')
       end
  
       def group(ungrouped)
@@ -222,7 +226,7 @@ module Jekyll
       def group_keys
         return @group_keys unless @group_keys.nil?
 
-        @group_keys = Array(config['group_by'])
+        @group_keys = Array((group_by.nil? || group_by.empty?) ? config['group_by'] : group_by)
           .map { |key| key.to_s.split(/\s*,\s*/) }
           .flatten
           .map { |key| key == 'month' ? 'month_numeric' : key }

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -202,10 +202,18 @@ module Jekyll
           .flatten
       end
 
-      def group?
-        (group_by.nil? && config['group_by'] != 'none') || (!group_by.nil? && group_by != 'none')
+      def group_by
+        if group_by.nil? || group_by.empty?
+          @group_by = config['group_by']
+        else
+          @group_by = 'none'
+        end
       end
  
+      def group?
+        group_by != 'none'
+      end
+
       def group(ungrouped)
         def grouper(items,keys,order)
           groups = items
@@ -226,7 +234,7 @@ module Jekyll
       def group_keys
         return @group_keys unless @group_keys.nil?
 
-        @group_keys = Array((group_by.nil? || group_by.empty?) ? config['group_by'] : group_by)
+        @group_keys = Array(group_by)
           .map { |key| key.to_s.split(/\s*,\s*/) }
           .flatten
           .map { |key| key == 'month' ? 'month_numeric' : key }


### PR DESCRIPTION
By using `--group_by` in `bibliography` tag, users override the global `group_by` setting in `_config.yaml`.