### PR TITLE
Export authors into an array under entry.author_array

### DIFF
--- a/features/bibtex.feature
+++ b/features/bibtex.feature
@@ -142,6 +142,33 @@ Feature: BibTeX
     And the "_site/scholar.html" file should exist
     And I should see "<abbr>1 book \[ruby\]</abbr>Matsumoto" in "_site/scholar.html"
 
+  @tags @bibliography @config @template
+  Scenario: Simple Bibliography With Custom Template
+    Given I have a scholar configuration with:
+      | key                   | value                                         |
+      | source                | ./_bibliography                               |
+      | bibliography_template | <abbr>{{index}} {{entry.type}} [{{key}}]</abbr>{{entry.author_array[1].last}} |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    And I should see "<abbr>1 book \[ruby\]</abbr>Matsumoto" in "_site/scholar.html"
+
   @tags @filter
   Scenario: Filtered Bibliography Loaded From Default Directory
     Given I have a scholar configuration with:

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -485,10 +485,14 @@ module Jekyll
           e[key.to_s] = value.to_s
 
           if value.is_a?(BibTeX::Names)
+            e["#{key}_array"] = arr = []
             value.each.with_index do |name, idx|
+              parts = {}
               name.each_pair do |k, v|
                 e["#{key}_#{idx}_#{k}"] = v.to_s
+                parts[k.to_s] = v.to_s
               end
+              arr << parts
             end
           end
         end


### PR DESCRIPTION
This permits easier iteration over an arbitrary number of authors.

For example, I have a collection of author pages and would like to link them with my publication author lists, I can use the following template to link the pair together:
```liquid
{% for author in page.entry.author_array %}
{% assign matched = site.people | where:"lastname",author.last | first %}
{% if matched %}<a href="{{ matched.url }}">{% endif %}{{ author.first }} {{ author.last }}{% if matched %}</a>{% endif %}
{% endfor %}
```