### PR TITLE
Details page page.title variable should use LaTeX filtered entry

### DIFF
--- a/features/details.feature
+++ b/features/details.feature
@@ -60,6 +60,7 @@ Feature: Details
       <html>
       <head></head>
       <body>
+      Page title: {{ page.title }}
       Title: {{ page.entry.title }}
       {{ page.entry.bibtex }}
       </body>
@@ -68,6 +69,7 @@ Feature: Details
     When I run jekyll
     Then the _site directory should exist
     And the "_site/bibliography/ruby.html" file should exist
+    And I should see "Page title: An Umlaut ä!" in "_site/bibliography/ruby.html"
     And I should see "Title: An Umlaut ä!" in "_site/bibliography/ruby.html"
     And I should see "title = {An Umlaut \\\"a!}" in "_site/bibliography/ruby.html"
 
@@ -93,6 +95,7 @@ Feature: Details
       <html>
       <head></head>
       <body>
+      Page title: {{ page.title }}
       Title: {{ page.entry.title }}
       {{ page.entry.bibtex }}
       </body>
@@ -101,6 +104,7 @@ Feature: Details
     When I run jekyll
     Then the _site directory should exist
     And the "_site/bibliography/ruby.html" file should exist
+    And I should see "Page title: An Umlaut \\\"a!" in "_site/bibliography/ruby.html"
     And I should see "Title: An Umlaut \\\"a!" in "_site/bibliography/ruby.html"
     And I should see "title = {An Umlaut \\\"a!}" in "_site/bibliography/ruby.html"
 

--- a/lib/jekyll/scholar/generators/details.rb
+++ b/lib/jekyll/scholar/generators/details.rb
@@ -15,8 +15,8 @@ module Jekyll
         process(@name)
         read_yaml(File.join(base, '_layouts'), config['details_layout'])
 
-        data['title'] = entry.title.to_s if entry.field?(:title)
         data.merge!(reference_data(entry))
+        data['title'] = data['entry']['title'] if data['entry'].has_key?('title')
       end
 
     end


### PR DESCRIPTION
(Sorry, I just found this bug as you released 5.7.0)