### PR TITLE
Add filter for \superscript LaTeX command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ default configuration is as follows:
       join_strings:    true
       
       use_raw_bibtex_entry: false
+      bibtex_filters:
+      - superscript
+      - latex
 
       details_dir:    bibliography
       details_layout: bibtex.html
@@ -129,6 +132,12 @@ group. The display names for entry types are specified with
 extended or overridden. For example, the default name for `article` is
 *Journal Articles*, but it can be changed to *Papers* using
 `type_name: { article => 'Papers' }`.
+
+The `bibtex_filters` option configures which
+[BibTeX-Ruby](https://github.com/inukshuk/bibtex-ruby) formatting filters
+values of entries should be passed through. This defaults to the `latex`
+filter which converts LaTeX character escapes into unicode, and `superscript`
+which converts the `\textsuperscript` command into a HTML `<sup>` tag.
 
 ### Bibliographies
 

--- a/features/filter.feature
+++ b/features/filter.feature
@@ -228,3 +228,54 @@ Feature: BibTeX
     Then the _site directory should exist
     And the "_site/scholar.html" file should exist
     And I should see "\[Pragmatic Bookshelf\]\(https://pragprog.com\)" in "_site/scholar.html"
+
+  @tags @superscript
+  Scenario: LaTeX Superscript as HTML
+    Given I have a scholar configuration with:
+      | key    | value             |
+      | source | ./_bibliography   |
+    And I have the following BibTeX filters:
+      | superscript |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @misc{pickaxe,
+        title     = {This is \textsuperscript{superscript text}.}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    And I should see "This is <sup>superscript text</sup>." in "_site/scholar.html"
+
+  @tags @superscript
+  Scenario: LaTeX Superscript with embedded LaTeX chars as HTML
+    Given I have a scholar configuration with:
+      | key    | value             |
+      | source | ./_bibliography   |
+    And I have the following BibTeX filters:
+      | superscript |
+      | latex       |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @misc{pickaxe,
+        title     = {\textsuperscript{\"u \"{u} \v{z}}}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    And I should see "<sup>ü ü ž</sup>" in "_site/scholar.html"

--- a/lib/jekyll/scholar.rb
+++ b/lib/jekyll/scholar.rb
@@ -21,3 +21,4 @@ require 'jekyll/scholar/tags/reference'
 require 'jekyll/scholar/generators/details'
 
 require 'jekyll/scholar/plugins/markdown_links'
+require 'jekyll/scholar/plugins/superscript'

--- a/lib/jekyll/scholar/defaults.rb
+++ b/lib/jekyll/scholar/defaults.rb
@@ -17,7 +17,7 @@ module Jekyll
       'repository'             => nil,
 
       'bibtex_options'         => { :strip => false, :parse_months => true },
-      'bibtex_filters'         => [ :latex ],
+      'bibtex_filters'         => [ :superscript, :latex ],
       'bibtex_skip_fields'     => [ :abstract, :month_numeric ],
 
       'replace_strings'        => true,

--- a/lib/jekyll/scholar/plugins/superscript.rb
+++ b/lib/jekyll/scholar/plugins/superscript.rb
@@ -1,0 +1,12 @@
+module Jekyll
+  class Scholar
+    class Superscript < BibTeX::Filter
+      def apply(value)
+        # Use of \g<1> pattern back-reference to allow for capturing nested {} groups
+        value.to_s.gsub(/\\textsuperscript(\{((?:.|\g<1>)*)\})/) {
+          "<sup>#{$2}</sup>"
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This filter converts \textsuperscript latex formatting into <sup> html tags.

Basically works, but should probably have a test case and documentation in README.md as well.