### PR TITLE
Make bibtex converter use configured filters.

### DIFF
--- a/features/bibtex.feature
+++ b/features/bibtex.feature
@@ -63,6 +63,24 @@ Feature: BibTeX
     And the "_site/references.html" file should exist
     And I should see "Look, an umlaut: ü!" in "_site/references.html"
 
+  @superscript
+  Scenario: Simple Bibliography with LaTeX superscript
+    Given I have a scholar configuration with:
+      | key   | value |
+      | style | apa   |
+    And I have a page "references.bib":
+      """
+      ---
+      ---
+      @misc{umlaut,
+        title     = {Look, \textsuperscript{superscript}!},
+      }
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/references.html" file should exist
+    And I should see "Look, <sup>superscript</sup>!" in "_site/references.html"
+
   @tags @bibtex
   Scenario: Embedded BibTeX
     Given I have a scholar configuration with:

--- a/lib/jekyll/scholar/converters/bibtex.rb
+++ b/lib/jekyll/scholar/converters/bibtex.rb
@@ -30,7 +30,8 @@ module Jekyll
       end
 
       def convert(content)
-        content = BibTeX.parse(content, :strict => true, :include => [:meta_content], :filter => [:latex]).map do |b|
+        content = BibTeX.parse(content, :strict => true, :include => [:meta_content],
+                               :filter => @config['scholar']['bibtex_filters']).map do |b|
           if b.respond_to?(:to_citeproc)
             render_bibliography b
           else


### PR DESCRIPTION
The bibtex converter class was not making use of the `bibtex_filters`
global configuration option.