### PR TITLE
Process bibliography tag in the same way as the details page generator

### DIFF
--- a/features/bibtex.feature
+++ b/features/bibtex.feature
@@ -368,4 +368,4 @@ Feature: BibTeX
     When I run jekyll
     Then the _site directory should exist
     And the "_site/scholar.html" file should exist
-    And I should see "{%raw%}@book" in "_site/scholar.html"
+    And I should not see "{%[\w*]raw[\w*]%}" in "_site/scholar.html"

--- a/features/details.feature
+++ b/features/details.feature
@@ -107,6 +107,40 @@ Feature: Details
     And I should see "Page title: An Umlaut \\\"a!" in "_site/bibliography/ruby.html"
     And I should see "Title: An Umlaut \\\"a!" in "_site/bibliography/ruby.html"
     And I should see "title = {An Umlaut \\\"a!}" in "_site/bibliography/ruby.html"
+    
+
+  @generators @bibtex
+  Scenario: Raw input can be turned off, and should not generate {%raw%} tags on the details page
+    Given I have a scholar configuration with:
+      | key            | value             |
+      | source         | ./_bibliography   |
+      | details_layout | details.html      |
+      | bibtex_filters |                   |
+      | use_raw_bibtex_entry | true        |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby,
+        title     = {{ some test }}
+      """
+    And I have a "_layouts" directory
+    And I have a file "_layouts/details.html":
+      """
+      ---
+      ---
+      <html>
+      <head></head>
+      <body>
+      Page title: {{ page.title }}
+      Title: {{ page.entry.title }}
+      {{ page.entry.bibtex }}
+      </body>
+      </html>
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/bibliography/ruby.html" file should exist
+    And I should not see "{%raw%}" in "_site/bibliography/ruby.html"
 
   @tags @details
   Scenario: Links to Detail Pages are Generated Automatically

--- a/features/details.feature
+++ b/features/details.feature
@@ -109,8 +109,8 @@ Feature: Details
     And I should see "title = {An Umlaut \\\"a!}" in "_site/bibliography/ruby.html"
     
 
-  @generators @bibtex
-  Scenario: Raw input can be turned off, and should not generate {%raw%} tags on the details page
+  @generators
+  Scenario: Raw input can be turned on, but should not generate any {%raw%} tags on the details page, and also not parse the liquid tags inside the bibtex
     Given I have a scholar configuration with:
       | key            | value             |
       | source         | ./_bibliography   |
@@ -120,8 +120,20 @@ Feature: Details
     And I have a "_bibliography" directory
     And I have a file "_bibliography/references.bib":
       """
-      @book{ruby,
-        title     = {{ some test }}
+      @book{sdf,
+        title     = {{SDF^3}}
+        }
+      """
+    And I have a file "bibliography.html":
+      """
+      ---
+      ---
+      <html>
+      <head></head>
+      <body>
+      {%bibliography%}
+      </body>
+      </html>
       """
     And I have a "_layouts" directory
     And I have a file "_layouts/details.html":
@@ -139,8 +151,9 @@ Feature: Details
       """
     When I run jekyll
     Then the _site directory should exist
-    And the "_site/bibliography/ruby.html" file should exist
-    And I should not see "{%raw%}" in "_site/bibliography/ruby.html"
+    And the "_site/bibliography/sdf.html" file should exist
+    And I should not see "{%raw%}" in "_site/bibliography/sdf.html"
+    And I should see "SDF\^3" in "_site/bibliography/sdf.html"
 
   @tags @details
   Scenario: Links to Detail Pages are Generated Automatically

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -455,14 +455,23 @@ module Jekyll
 
       def bibliography_tag(entry, index)
         return missing_reference unless entry
-
-        liquid_template.render(
+        
+        tmp = liquid_template.render(
           reference_data(entry,index)
             .merge(site.site_payload)
             .merge({
               'index' => index,
               'details' => details_link_for(entry)
             }),
+          {
+            :registers => { :site => site },
+            :filters => [Jekyll::Filters]
+          }
+        )
+        # process the generated reference with Liquid, to get the same behaviour as 
+        # when it is used on a page
+        Liquid::Template.parse(tmp).render(
+          site.site_payload, 
           {
             :registers => { :site => site },
             :filters => [Jekyll::Filters]


### PR DESCRIPTION
Added (and fixed) tests for generating the raw bibtex output. The details page generator renders the page as a Liquid template, and therefore does not show the {%raw%} (as expected). The {%bibliography%} tag, however, does not, and passes it as plain text to the output.

I've added a liquid rendering (I think similar to the one done on the details page), and this fixes the inconsistency between the two outputs.

Comments on e.g. simplification or improving the robustness are appreciated.