### PR TITLE
Preventing @string objects being passed to the renderer.

### DIFF
--- a/features/string.feature
+++ b/features/string.feature
@@ -112,3 +112,30 @@ Feature: String replacement
     Then the _site directory should exist
     And the "_site/scholar.html" file should exist
     And I should see "<i>\"The \" # \"Ruby\" # \" Programming Language\"</i>" in "_site/scholar.html"
+
+    @tags @string
+    Scenario: String replacement with queries involving negative conditions
+      Given I have a scholar configuration with:
+        | key    | value             |
+        | source | ./_bibliography   |
+      And I have a "_bibliography" directory
+      And I have a file "_bibliography/references.bib":
+        """
+        @string{ rubypl = "The Ruby Programming Language" }
+        @book{ruby,
+          title     = rubypl,
+          author    = {Flanagan, David and Matsumoto, Yukihiro},
+          year      = {2008},
+          publisher = {O'Reilly Media}
+        }
+        """
+      And I have a page "scholar.html":
+        """
+        ---
+        ---
+        {% bibliography -f references --query !@article %}
+        """
+      When I run jekyll
+      Then the _site directory should exist
+      And the "_site/scholar.html" file should exist
+      And I should see "<i>The Ruby Programming Language</i>" in "_site/scholar.html"

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -161,7 +161,7 @@ module Jekyll
       end
 
       def entries
-        sort bibliography[query || config['query']]
+        sort bibliography[query || config['query']].select { |x| x.instance_of? BibTeX::Entry}
       end
 
       def offset


### PR DESCRIPTION
When negative queries are used objects that are not bibtex entries get passed the the 'entries' function to methods that render bibliography entries. These @string and @preface objects cause errors when functions expect to find certain fields in them.

I have written a test to reproduce this case and one way of ensuring the entries function only returns an array of entries.