### PR TITLE
Allow style paths relative to Jekyll's source directory

### DIFF
--- a/features/bibtex.feature
+++ b/features/bibtex.feature
@@ -369,3 +369,49 @@ Feature: BibTeX
     Then the _site directory should exist
     And the "_site/scholar.html" file should exist
     And I should not see "{%[\w*]raw[\w*]%}" in "_site/scholar.html"
+
+  @config @bibliography @style
+  Scenario: A custom style with Jekyll source directory set
+    Given I have a configuration file with:
+      | key     | value              |
+      | source  | src                |
+    And I have a scholar configuration with:
+      | key     | value              |
+      | source  | _bibliography      |
+      | style   | _styles/custom.csl |
+    And I have a "src" directory
+    And I have a "src/_bibliography" directory
+    And I have a "src/_styles" directory
+    And I have a file "src/_styles/custom.csl":
+      """
+      <style>
+        <citation>
+          <layout>
+            <text variable="title"/>
+          </layout>
+        </citation>
+        <bibliography>
+          <layout>
+            <text variable="title"/>
+          </layout>
+        </bibliography>
+      </style>
+      """
+    And I have a file "src/_bibliography/references.bib":
+      """
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a page "src/scholar.html":
+      """
+      ---
+      ---
+      {% bibliography --style _styles/custom.csl %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And I should see "The Ruby Programming Language" in "_site/scholar.html"

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -688,15 +688,23 @@ module Jekyll
         self
       end
 
-      def style_cache(style)
-        style_path =
-          if Pathname.new(style).absolute?
-            style
+      # Try to resolve local style paths
+      # relative to Jekyll's source directory
+      def style_cache(style_name)
+        style =
+          if site && site.source
+            site_relative_style = File.join(site.source, style_name)
+
+            if Pathname.new(style_name).relative? && File.exist?(site_relative_style)
+              site_relative_style
+            else
+              style_name
+            end
           else
-            File.join(site.source, style)
+            style_name
           end
 
-        STYLES[style_path]
+        STYLES[style]
       end
     end
 

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -592,12 +592,12 @@ module Jekyll
           item.label = label unless label.nil?
 
           item
-        }, STYLES[style].citation
+        }, style_cache(style).citation
       end
 
       def render_bibliography(entry, index = nil)
         renderer.render citation_item_for(entry, index),
-          STYLES[style].bibliography
+          style_cache(style).bibliography
       end
 
       def citation_item_for(entry, citation_number = nil)
@@ -686,6 +686,17 @@ module Jekyll
         @context, @site, = context, context.registers[:site]
         config.merge!(site.config['scholar'] || {})
         self
+      end
+
+      def style_cache(style)
+        style_path =
+          if Pathname.new(style).absolute?
+            style
+          else
+            File.join(site.source, style)
+          end
+
+        STYLES[style_path]
       end
     end
 


### PR DESCRIPTION
Re: #161 

In this diff I check whether style paths appear to be relative to the jekyll source directory, and treat them as such if the file exists.

All current tests pass, however writing a new test seems non-trivial. Suggestions?