### PR TITLE
Adds support for bibliography tags in layouts

### DIFF
--- a/features/layout.feature
+++ b/features/layout.feature
@@ -1,0 +1,51 @@
+Feature: Bibliographies in Layouts
+  As a scholar who likes to blog
+  I want to cite references on my website
+  And generate bibliographies as part of a common layout
+
+  Scenario: I want every page to have cited-only references from a single bibliography
+    Given I have a scholar configuration with:
+      | key    | value             |
+      | source | ./_bibliography   |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      },
+      @book{smalltalk,
+        title     = {Smalltalk Best Practice Patterns},
+        author    = {Kent Beck},
+        year      = {1996},
+        publisher = {Prentice Hall}
+      }
+      """
+    And I have a "_layouts" directory
+    And I have a file "_layouts/page.html":
+      """
+      ---
+      ---
+      <div>
+        {{ content }}
+      </div>
+      <div>
+        {% bibliography --cited %}
+      </div>
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      layout: page
+      ---
+      {% cite smalltalk %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    And I should not see "<i>The Ruby Programming Language</i>" in "_site/scholar.html"
+    And I should see "<i>Smalltalk Best Practice Patterns</i>" in "_site/scholar.html"
+
+

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -610,7 +610,7 @@ module Jekyll
       end
 
       def cited_keys
-        context['cited'] ||= []
+        context['cited'] = context.environments.first['page']['cited']  ||= []
       end
 
       def citation_number(key)
@@ -663,7 +663,7 @@ module Jekyll
       end
 
       def cited_references
-        context && context['cited'] || []
+        context && cited_keys
       end
 
       def keys


### PR DESCRIPTION
Specifically, addresses the use case of wanting a bibliography for
every page that uses a layout. This patch modifies the cited_keys
function so that the backing array store is attached to the page's data.
This allows the layout to see the cited references when it renders the
bibliography (with the `--cited` option). Previously this did not work
because the cited_keys array was attached to the Jekyll context, which
is different between the layout and the page.