### PR TITLE
Issue 186: Return count of bibliography items

### DIFF
--- a/features/186.feature
+++ b/features/186.feature
@@ -1,0 +1,73 @@
+Feature: BibTeX
+  As a scholar who likes to blog
+  I want to reference cool papers and books from my bibliography
+
+  @tags @bibliography
+  Scenario: Simple bibliography count
+    Given I have a scholar configuration with:
+      | key    | value             |
+      | source | ./_bibliography   |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{smalltalk,
+        title     = {Smalltalk Best Practice Patterns},
+        author    = {Kent Beck},
+        year      = {1996},
+        publisher = {Prentice Hall}
+      }
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography --bib_count -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    And I should not see "<i>The Ruby Programming Language</i>" in "_site/scholar.html"
+    And I should not see "<i>Smalltalk Best Practice Patterns</i>" in "_site/scholar.html"
+    And I should see "2" in "_site/scholar.html"
+
+  @tags @bibliography
+  Scenario: Simple bibliography count with query
+    Given I have a scholar configuration with:
+      | key    | value             |
+      | source | ./_bibliography   |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{smalltalk,
+        title     = {Smalltalk Best Practice Patterns},
+        author    = {Kent Beck},
+        year      = {1996},
+        publisher = {Prentice Hall}
+      }
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography --bib_count -f references --query @book[year <= 2000] %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    And I should not see "<i>The Ruby Programming Language</i>" in "_site/scholar.html"
+    And I should not see "<i>Smalltalk Best Practice Patterns</i>" in "_site/scholar.html"
+    And I should see "1" in "_site/scholar.html"
+
+

--- a/lib/jekyll/scholar/tags/bibliography.rb
+++ b/lib/jekyll/scholar/tags/bibliography.rb
@@ -50,7 +50,12 @@ module Jekyll
           bibliography = render_items(items)
         end
 
-        bibliography
+        if bib_count 
+           puts entries.size
+           entries.size
+        else 
+           bibliography
+        end
       end
 
       def render_groups(groups)

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -30,6 +30,11 @@ module Jekyll
         return if arguments.nil? || arguments.empty?
 
         parser = OptionParser.new do |opts|
+
+          opts.on('-b', '--bib_count') do |bib_count|
+            @bib_count = true
+          end
+
           opts.on('-c', '--cited') do |cited|
             @cited = true
           end
@@ -96,10 +101,14 @@ module Jekyll
           end
         end
 
-        argv = arguments.split(/(\B-[cCfqptTsgGOlLomA]|\B--(?:cited(_in_order)?|file|query|prefix|text|style|group_(?:by|order)|type_order|template|locator|label|offset|max|suppress_author|))/)
+        argv = arguments.split(/(\B-[bcCfqptTsgGOlLomA]|\B--(?:cited(_in_order)?|bib_count|file|query|prefix|text|style|group_(?:by|order)|type_order|template|locator|label|offset|max|suppress_author|))/)
 
         parser.parse argv.map(&:strip).reject(&:empty?)
       end
+
+      def bib_count 
+         @bib_count
+      end 
 
       def locators
         @locators ||= []


### PR DESCRIPTION
This handles part of the issue: #186.  Added a --bib_count
option to the bibliography tag to return the number of items.
  