### PR TITLE
fix for nil entries crashing because of details_file_for

### DIFF
--- a/lib/jekyll/scholar/tags/bibliography.rb
+++ b/lib/jekyll/scholar/tags/bibliography.rb
@@ -59,7 +59,7 @@ module Jekyll
       end
 
       def render_items(items)
-        bibliography = items.each_with_index.map { |entry, index|
+        bibliography = items.compact.each_with_index.map { |entry, index|
           reference = bibliography_tag(entry, index + 1)
 
           if generate_details?


### PR DESCRIPTION
If a nil entry is in the list and `generate_details?` is true, the nil entry will be passed to `details_file_for` which attempts to look up the nil entry's key, and crashes.

This patch removes all nil entries before rendering.