### PR TITLE
support complex keys in repositories

### DIFF
--- a/features/repository.feature
+++ b/features/repository.feature
@@ -246,3 +246,46 @@ Feature: PDF Repository
     And I should see "The Ruby Programming Language" in "_site/scholar.html"
     And I should see "Link: /papers.dir/ruby.pdf" in "_site/scholar.html"
     And I should see "Slides: /papers.dir/ruby.slides.pdf" in "_site/scholar.html"
+
+  @repository
+  Scenario: A bibliography with a single entry with a complex name
+    Given I have a scholar configuration with:
+      | key                   | value             |
+      | source                | ./_bibliography   |
+      | repository            | papers            |
+      | bibliography_template | bibliography      |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{test:book/ruby/Flanagan08,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a "papers" directory
+    And I have a "papers/test_book" directory
+    And I have a "papers/test_book/ruby" directory
+    And I have a file "papers/test_book/ruby/Flanagan08.pdf":
+      """
+      The PDF
+      """
+    And I have a "_layouts" directory
+    And I have a file "_layouts/bibliography.html":
+      """
+      ---
+      ---
+      {{ reference }} Link: {{ link }}
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/papers/test_book/ruby/Flanagan08.pdf" file should exist
+    And I should see "The Ruby Programming Language" in "_site/scholar.html"
+    And I should see "Link: /papers/test_book/ruby/Flanagan08.pdf" in "_site/scholar.html"

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -371,7 +371,8 @@ module Jekyll
         base = Dir[site.source][0]
 
         Dir[File.join(site.source, repository_path, '**/*')].each do |path|
-          parts = File.basename(path).split(repository_file_delimiter, 2)
+          parts = Pathname(path).relative_path_from(Pathname(File.join(base, repository_path)))
+          parts = parts.to_path.split(repository_file_delimiter, 2)
           repo[parts[0]][parts[1]] =
             Pathname(path).relative_path_from(Pathname(base))
         end
@@ -570,7 +571,9 @@ module Jekyll
       end
 
       def repository_link_for(entry, base = base_url)
-        links = repository[entry.key]
+        name = entry.key.to_s.dup
+        name.gsub!(/[:\s]+/, '_')
+        links = repository[name]
         url   = links['pdf'] || links['ps']
 
         return unless url
@@ -579,7 +582,9 @@ module Jekyll
       end
 
       def repository_links_for(entry, base = base_url)
-        Hash[repository[entry.key].map { |ext, url|
+        name = entry.key.to_s.dup
+        name.gsub!(/[:\s]+/, '_')
+        Hash[repository[name].map { |ext, url|
           [ext, File.join(base, url)]
         }]
       end


### PR DESCRIPTION
Handle keys in `repository_link_for`, `repository_links_for`, and
`load_repository` the same way as in `details_file_for` to also support
slashes and colons here.

Note that I don't use ruby. Hope it's okay like this.