### PR TITLE
plugin to convert \emph tags to italics in html

### DIFF
--- a/lib/jekyll/scholar/plugins/italics.rb
+++ b/lib/jekyll/scholar/plugins/italics.rb
@@ -1,0 +1,13 @@
+module Jekyll
+  class Scholar
+    class Italics < BibTeX::Filter
+      def apply(value)
+        # Use of \g<1> pattern back-reference to allow for capturing nested {} groups.
+        # The first (outermost) capture of $1 is used.
+        value.to_s.gsub(/\\emph(\{(?:[^{}]|\g<1>)*\})/) {
+          "<i>#{$1[1..-2]}</i>"
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should convert `\emph` to `<i></i>` as per #242 