### PR TITLE
Update quote.rb to support option parsing

### DIFF
--- a/lib/jekyll/scholar/tags/quote.rb
+++ b/lib/jekyll/scholar/tags/quote.rb
@@ -11,6 +11,8 @@ module Jekyll
 
         @config = Scholar.defaults.dup
         @keys, arguments = split_arguments arguments
+
+        optparse(arguments)
       end
 
       def render(context)


### PR DESCRIPTION
This allows for options to be passed to the quote tag.

e.g: `{% quote source --locator 7 %}{% endquote %}`