### PR TITLE
Add ruby 2.6 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ sudo: false
 cache: bundler
 matrix:
   include:
-  - rvm: 2.5
+  - rvm: 2.6
     env: WITH_COVERALLS=true
+  - rvm: 2.5
+    env: WITH_COVERALLS=false
   - rvm: 2.4
     env: WITH_COVERALLS=false
   - rvm: 2.3


### PR DESCRIPTION
Also, move coverage report to this ruby version so there is still only one coverage report generated per build.