### PR TITLE
Allow detail page URLs to be customised by the user

### DIFF
--- a/features/details.feature
+++ b/features/details.feature
@@ -334,6 +334,59 @@ Feature: Details
     And I should see "<a[^>]+href=\"/bibliography/ruby/\">" in "_site/scholar/index.html"
     And the "_site/bibliography/ruby/index.html" file should exist
 
+  @tags @details
+  Scenario: Detail page URLs can have custom permalinks
+    Given I have a configuration file with "permalink" set to "/:title/"
+    And I have a scholar configuration with:
+      | key                | value                                  |
+      | source             | ./_bibliography                        |
+      | bibliography       | references                             |
+      | details_layout     | details.html                           |
+      | details_permalink  | /:details_dir/:year/:doi:extension     |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{rubydoi,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media},
+        doi       = {10.0000/1111}
+      }
+
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a "_layouts" directory
+    And I have a file "_layouts/details.html":
+      """
+      ---
+      ---
+      <html>
+      <head></head>
+      <body>
+      {{ page.entry.title }}
+      </body>
+      </html>
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar/index.html" file should exist
+    And I should see "<a[^>]+href=\"/bibliography/2008/10.0000/1111/\">" in "_site/scholar/index.html"
+    And I should see "<a[^>]+href=\"/bibliography/2008/ruby/\">" in "_site/scholar/index.html"
+    And the "_site/bibliography/2008/10.0000/1111/index.html" file should exist
+    And the "_site/bibliography/2008/ruby/index.html" file should exist
+
   @generators @parse_months
   Scenario: Months are parsed by default
     Given I have a scholar configuration with:

--- a/lib/jekyll/scholar/defaults.rb
+++ b/lib/jekyll/scholar/defaults.rb
@@ -46,6 +46,22 @@ module Jekyll
       'details_dir'            => 'bibliography',
       'details_layout'         => 'bibtex.html',
       'details_link'           => 'Details',
+
+      # 'details_permalink': URL template for generating the filenames of the details pages.
+      #
+      # Example: if we had a citation key 'ruby':
+      #   '/:details_dir/:year/:key:extension' would produce:
+      #     '/bibliography/2008/ruby.html'        if global permalinks end in .html
+      #     '/bibliography/2008/ruby/index.html'  if global permalinks end in "/" or are set to "pretty"
+      #
+      # Valid template parameters:
+      #    ":details_dir"   The value of the details_dir field in the scholar config
+      #    ":key"           The bibtex citation key.
+      #    ":doi"           The DOI. If the DOI is missing or blank, this returns the citation key. 
+      #    ":extension"     Either of ".html" or "/index.html" depending upon the global permalink setting.
+      # Template parameters can also include any key defined in the bibtex file, e.g. ":year", ":title", etc.
+      # Bibtex keys such as 'title' are slugified in the same way as Jekyll treats blog post titles.
+      'details_permalink'       => '/:details_dir/:key:extension', 
       'use_raw_bibtex_entry'   => true,
 
       'bibliography_class'     => 'bibliography',

--- a/lib/jekyll/scholar/generators/details.rb
+++ b/lib/jekyll/scholar/generators/details.rb
@@ -5,10 +5,12 @@ module Jekyll
       include Scholar::Utilities
 
       def initialize(site, base, dir, entry)
-        @site, @base, @dir = site, base, dir
+        @site, @base, @dir, @entry = site, base, dir, entry
 
         @config = Scholar.defaults.merge(site.config['scholar'] || {})
 
+        # Specify a temporary filename for now based upon the citation key. Jekyll
+        # will modify this according to the URL template below
         @name = entry.key.to_s.gsub(/[:\s]+/, '_')
         @name << '.html'
 
@@ -19,6 +21,10 @@ module Jekyll
         data['title'] = data['entry']['title'] if data['entry'].has_key?('title')
       end
 
+      def url
+        # Reuse the logic in the utilities module for deciding URLs
+        details_link_for(@entry)
+      end
     end
 
     class DetailsGenerator < Generator


### PR DESCRIPTION
This pull request adds a new configuration setting "details_permalink" to allow for end users to customise the URLs of the details pages. For example, instead of URLs being hardcoded to be the citation key, the user may include the year, DOI, title, etc. This is similar to how normal Jekyll blog posts follow the URL pattern defined in the site's config file.

The default settings reproduce the existing behaviour of jekyll-scholar, so URLs will not change unless the user explicitly configures the new setting.

The pull request also includes a unit test for the new functionality. 
