### PR TITLE
Allow newer versions of Jekyll

### DIFF
--- a/jekyll-scholar.gemspec
+++ b/jekyll-scholar.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = s.name
 
-  s.add_runtime_dependency('jekyll', '~> 3.0')
+  s.add_runtime_dependency('jekyll', '>= 3.0')
   s.add_runtime_dependency('citeproc-ruby', '~> 1.0')
   s.add_runtime_dependency('csl-styles', '~> 1.0')
   s.add_runtime_dependency('bibtex-ruby', '~> 4.0', '>= 4.0.13')


### PR DESCRIPTION
This gem works with at least versions 3 and 4. I don't know if it's better to be explicit about limiting to those versions or just allowing any version that's at least 3.