### PR TITLE
Use page front matter to override configuration

### DIFF
--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -774,8 +774,9 @@ module Jekyll
       end
 
       def set_context_to(context)
-        @context, @site, = context, context.registers[:site]
+        @context, @site, @page, = context, context.registers[:site], context.registers[:page]
         config.merge!(site.config['scholar'] || {})
+        config.merge!(page['scholar'] || {})
         self
       end
 


### PR DESCRIPTION
Closes #95

Turns out, this is incredibly simple (2 lines changed! :smile: ).
When Jekyll passes a context to the `render` method, it has a register
with the hash `:page` which bundles all the front matter defined for the
given page. To make life easier, the front matter configuration matches
the schema for the `scholar` configuration in `_config.yml` exactly.

Now, simply merge the configuration hashes!

@inukshuk please let me know if I need to add anything :smile: 