### PR TITLE
Custom bibliography list class and attributes

### DIFF
--- a/features/list_class_attributes.feature
+++ b/features/list_class_attributes.feature
@@ -128,3 +128,42 @@ Feature: Set custom class or attributes in lists
     And I should see "</ol>" in "_site/scholar.html"
     And I should see "<ol class=\"bibliography__custom\" reversed=\"reversed\">" in "_site/scholar-reversed-custom.html"
     And I should see "</ol>" in "_site/scholar-reversed-custom.html"
+
+  @tags @bibliography
+   Scenario: Reversed bibliography_list_attributes: {reversed}
+    Given I have a scholar configuration with:
+      | key    | value             |
+      | source | ./_bibliography   |
+    Given I have the following bibliography_list_attributes:
+      | key      | value      |
+      | reversed | "reversed" |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      @book{smalltalk,
+        title     = {Smalltalk Best Practice Patterns},
+        author    = {Kent Beck},
+        year      = {1996},
+        publisher = {Prentice Hall}
+        }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+ 
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    And I should see "<i>The Ruby Programming Language</i>" in "_site/scholar.html"
+    And I should see "<i>Smalltalk Best Practice Patterns</i>" in "_site/scholar.html"
+    And I should see "<ol class=\"bibliography\" reversed="reversed">" in "_site/scholar.html"
+    And I should see "</ol>" in "_site/scholar.html"

--- a/features/list_class_attributes.feature
+++ b/features/list_class_attributes.feature
@@ -1,0 +1,130 @@
+Feature: Set custom class or attributes in lists
+  As a scholar who likes to blog
+  I want to publish my BibTeX bibliography on my blog
+  In order to share my awesome references with my peers
+
+  @tags @bibliography
+   Scenario: Default bibliography_list_attributes: {}
+    Given I have a scholar configuration with:
+      | key    | value             |
+      | source | ./_bibliography   |
+      | bibliography_list_attributes | {} |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      @book{smalltalk,
+        title     = {Smalltalk Best Practice Patterns},
+        author    = {Kent Beck},
+        year      = {1996},
+        publisher = {Prentice Hall}
+        }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    And I should see "<i>The Ruby Programming Language</i>" in "_site/scholar.html"
+    And I should see "<i>Smalltalk Best Practice Patterns</i>" in "_site/scholar.html"
+    And I should see "<ol class=\"bibliography\">" in "_site/scholar.html"
+    And I should see "</ol>" in "_site/scholar.html"
+
+  @tags @bibliography
+   Scenario: Default bibliography_list_attributes: {} with reverse override
+    Given I have a scholar configuration with:
+      | key    | value             |
+      | source | ./_bibliography   |
+      | bibliography_list_attributes | {} |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      @book{smalltalk,
+        title     = {Smalltalk Best Practice Patterns},
+        author    = {Kent Beck},
+        year      = {1996},
+        publisher = {Prentice Hall}
+        }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    And I have a page "scholar-reversed.html":
+      """
+      ---
+      ---
+      {% bibliography -f references --bibliography_list_attributes {:reversed=>'reversed'} %}
+      """
+ 
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    And I should see "<i>The Ruby Programming Language</i>" in "_site/scholar.html"
+    And I should see "<i>Smalltalk Best Practice Patterns</i>" in "_site/scholar.html"
+    And I should see "<ol class=\"bibliography\">" in "_site/scholar.html"
+    And I should see "</ol>" in "_site/scholar.html"
+    And I should see "<ol class=\"bibliography\" reversed=\"reversed\">" in "_site/scholar-reversed.html"
+    And I should see "</ol>" in "_site/scholar-reversed.html"
+
+  @tags @bibliography
+   Scenario: Default bibliography_list_attributes: {} with reverse override and custom class
+    Given I have a scholar configuration with:
+      | key    | value             |
+      | source | ./_bibliography   |
+      | bibliography_list_attributes | {} |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        publisher = {O'Reilly Media}
+      }
+      @book{smalltalk,
+        title     = {Smalltalk Best Practice Patterns},
+        author    = {Kent Beck},
+        year      = {1996},
+        publisher = {Prentice Hall}
+        }
+      """
+    And I have a page "scholar.html":
+      """
+      ---
+      ---
+      {% bibliography -f references %}
+      """
+    And I have a page "scholar-reversed-custom.html":
+      """
+      ---
+      ---
+      {% bibliography -f references --bibliography_list_attributes {:reversed=>'reversed', :class=>'bibliography__custom'} %}
+      """
+ 
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/scholar.html" file should exist
+    And I should see "<i>The Ruby Programming Language</i>" in "_site/scholar.html"
+    And I should see "<i>Smalltalk Best Practice Patterns</i>" in "_site/scholar.html"
+    And I should see "<ol class=\"bibliography\">" in "_site/scholar.html"
+    And I should see "</ol>" in "_site/scholar.html"
+    And I should see "<ol class=\"bibliography__custom\" reversed=\"reversed\">" in "_site/scholar-reversed-custom.html"
+    And I should see "</ol>" in "_site/scholar-reversed-custom.html"

--- a/features/step_definitions/scholar_steps.rb
+++ b/features/step_definitions/scholar_steps.rb
@@ -45,6 +45,15 @@ Given(/^I have the following raw BibTeX filters:$/) do |table|
   end
 end
 
+Given(/^I have the following bibliography_list_attributes:$/) do |table|
+  File.open('_config.yml', 'a') do |f|
+    f.write("  bibliography_list_attributes:\n")
+    table.hashes.each do |row|
+      f.write("    #{row["key"]}: #{row["value"]}\n")
+    end
+  end
+end
+
 Then(/^"(.*)" should come before "(.*)" in "(.*)"$/) do |p1, p2, file|
   data = File.open(file).readlines.join('')
 

--- a/lib/jekyll/scholar/tags/bibliography.rb
+++ b/lib/jekyll/scholar/tags/bibliography.rb
@@ -71,7 +71,7 @@ module Jekyll
         }.join("\n")
 
         content_tag bibliography_list_tag, bibliography,
-          { :class => config['bibliography_class'] }.merge(bibliography_list_attributes)
+          { :class => config['bibliography_class'] }.merge(config['bibliography_list_attributes']).merge(bibliography_list_attributes)
 
       end
 

--- a/lib/jekyll/scholar/tags/bibliography.rb
+++ b/lib/jekyll/scholar/tags/bibliography.rb
@@ -71,7 +71,7 @@ module Jekyll
         }.join("\n")
 
         content_tag bibliography_list_tag, bibliography,
-          { :class => config['bibliography_class'] }.merge(config['bibliography_list_attributes'])
+          { :class => config['bibliography_class'] }.merge(bibliography_list_attributes)
 
       end
 

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -67,6 +67,10 @@ module Jekyll
             @bibliography_list_tag = tag
           end
 
+          opts.on('-H', '--bibliography_list_attributes ATTS') do |atts|
+            @bibliography_list_attributes = atts
+          end
+
           opts.on('-p', '--prefix PREFIX') do |prefix|
             @prefix = prefix
           end
@@ -112,7 +116,7 @@ module Jekyll
           end
         end
 
-        argv = arguments.split(/(\B-[cCfhqptTsgGOlLomAr]|\B--(?:cited(_in_order)?|clear|bibliography_list_tag|file|query|prefix|text|style|group_(?:by|order)|type_order|template|locator|label|offset|max|suppress_author|remove_duplicates|))/)
+        argv = arguments.split(/(\B-[cCfhHqptTsgGOlLomAr]|\B--(?:cited(_in_order)?|clear|bibliography_list_tag|bibliography_list_attributes|file|query|prefix|text|style|group_(?:by|order)|type_order|template|locator|label|offset|max|suppress_author|remove_duplicates|))/)
 
         parser.parse argv.map(&:strip).reject(&:empty?)
       end
@@ -122,6 +126,14 @@ module Jekyll
           config['bibliography_list_tag']
         else
           @bibliography_list_tag
+        end
+      end
+
+      def bibliography_list_attributes
+        if @bibliography_list_attributes.nil?
+          {}
+        else
+          eval(@bibliography_list_attributes)
         end
       end
 


### PR DESCRIPTION
## Summary
This PR adds support for custom bibliography list classes, and attributes. I.e, the changes, expose the `bibliography_list_attributes` config option as an option in the `{% bibliography %}` Liquid tag.

NOTE: I am not a ruby developer. In fact I have never edited ruby code before this PR. Please review carefully and critically.

## Changes
1. Add an option to the `utilities.rb` `optparse` function named `bibliography_list_attributes`.
1. Add a function to `utilities.rb` named `bibliography_list_attributes`, which returns the passed `bibliography_list_attributes` argument if it was given, otherwise, returns an empty Hash `{}`.
1. The `bibliography_list_attributes` function is now called during the merge with `config['bibliography_class']` during the call to `render_item`. 
1. This merge enables custom HTML attributes to be passed, such as reversing the list with `--bibliography_list_attributes {:reversed=>'reversed'}`. Additionally, the class of the bibliography list can overridden by passing, e.g., `--bibliography_list_attributes {:class=>'bibliography__custom'}`.


## Potential problems?
* uses a call to `eval()` on a string that the user supplies. My google searches reveal this may be a security issue. I can see how it would be to run on server-side code, but I'm not sure this is an issue for the plugin's users.
* the argument input to `{% bibliography %}` needs to be given as ruby Hash code. This may be confusing and problematic for people using Jekyll without digging into the code.
* I have never written cucumber tests before. 
* I'm not sure the last cucumber test (`Scenario: Reversed bibliography_list_attributes: {:reversed}`) is actually written correctly. I.e., I'm not sure the test sets up the `_config.yml` file the way that a user would actually have it set up (below). I had to add a `scholar_steps` to process the `bibliography_list_attributes` to `config.yml` correctly. Maybe you can check this.
```yaml
scholar:
  bibliography_list_attributes:
    reversed: "reversed"
```
* `reversed` is a boolean html attribute to `ol`, so I don't think there is any way to "override" the reversed-ness of a list if `bibliography_list_attributes` is set in `_config.yml` as above.

## Thoughts
* My use case is that I want to have a reversed (descending) bibliography on my "publications" page, but have other bibliography (blog posts, research project pages) use an ascending list. This code makes that possible, without *breaking* anything, but I don't know if it's the best way to do it.
* Do you think there is a better way to do this? Can we take a "list" similar to `--query`` and then process it into a ruby Hash behind the scenes? This may be easier for the user.
* Another option could be to just add an argument `--reverse` that inverts whatever the default `bibliography_list_attributes` is set in `_config.yml`.
