### PR TITLE
add ", group: :jekyll_plugins"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 
 Or add it to your `Gemfile`:
 
-    gem 'jekyll-scholar'
+    gem 'jekyll-scholar', group: :jekyll_plugins
 
 ### Github Pages
 


### PR DESCRIPTION
without this, I couldn't solve `Liquid Exception: Liquid syntax error: Unknown tag 'bibliography'`

Please consider to approve this change.