### PR TITLE
Only generate the default details link if details_link is configured.

### DIFF
--- a/features/details.feature
+++ b/features/details.feature
@@ -40,6 +40,105 @@ Feature: Details
     And I should see "A Comment" in "_site/bibliography/ruby.html"
 
   @generators
+  Scenario: A bibliography with a single entry with link
+    Given I have a scholar configuration with:
+      | key            | value             |
+      | source         | ./_bibliography   |
+      | details_layout | details.html      |
+      | details_link   | Full details      |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        comment   = {A Comment},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a file "bibliography.html":
+      """
+      ---
+      ---
+      <html>
+      <head></head>
+      <body>
+      {%bibliography%}
+      </body>
+      </html>
+      """
+    And I have a "_layouts" directory
+    And I have a file "_layouts/details.html":
+      """
+      ---
+      ---
+      <html>
+      <head></head>
+      <body>
+      {{ page.title }}
+      {{ page.entry.comment }}
+      </body>
+      </html>
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/bibliography/ruby.html" file should exist
+    And I should see "The Ruby Programming Language" in "_site/bibliography/ruby.html"
+    And I should see "A Comment" in "_site/bibliography/ruby.html"
+    And I should see "Full details" in "_site/bibliography.html"
+
+  @generators
+  Scenario: A bibliography with a single entry but no link
+    Given I have a scholar configuration with:
+      | key            | value             |
+      | source         | ./_bibliography   |
+      | details_layout | details.html      |
+      | details_link   |                   |
+    And I have a "_bibliography" directory
+    And I have a file "_bibliography/references.bib":
+      """
+      @book{ruby,
+        title     = {The Ruby Programming Language},
+        author    = {Flanagan, David and Matsumoto, Yukihiro},
+        year      = {2008},
+        comment   = {A Comment},
+        publisher = {O'Reilly Media}
+      }
+      """
+    And I have a file "bibliography.html":
+      """
+      ---
+      ---
+      <html>
+      <head></head>
+      <body>
+      {%bibliography%}
+      </body>
+      </html>
+      """
+    And I have a "_layouts" directory
+    And I have a file "_layouts/details.html":
+      """
+      ---
+      ---
+      <html>
+      <head></head>
+      <body>
+      {{ page.title }}
+      {{ page.entry.comment }}
+      </body>
+      </html>
+      """
+    When I run jekyll
+    Then the _site directory should exist
+    And the "_site/bibliography/ruby.html" file should exist
+    And I should see "The Ruby Programming Language" in "_site/bibliography/ruby.html"
+    And I should see "A Comment" in "_site/bibliography/ruby.html"
+    And I should not see "Full details" in "_site/bibliography.html"
+
+
+  @generators
   Scenario: LaTeX conversion is applied to everything except the bibtex field
     Given I have a scholar configuration with:
       | key            | value             |

--- a/lib/jekyll/scholar/tags/bibliography.rb
+++ b/lib/jekyll/scholar/tags/bibliography.rb
@@ -61,7 +61,7 @@ module Jekyll
         bibliography = items.compact.each_with_index.map { |entry, index|
           reference = bibliography_tag(entry, index + 1)
 
-          if generate_details?
+          if generate_details_link?
             reference << link_to(details_link_for(entry),
               config['details_link'], :class => config['details_link_class'])
           end

--- a/lib/jekyll/scholar/tags/bibliography.rb
+++ b/lib/jekyll/scholar/tags/bibliography.rb
@@ -61,7 +61,7 @@ module Jekyll
         bibliography = items.compact.each_with_index.map { |entry, index|
           reference = bibliography_tag(entry, index + 1)
 
-          if generate_details_link?
+          if generate_details? && generate_details_link?
             reference << link_to(details_link_for(entry),
               config['details_link'], :class => config['details_link_class'])
           end

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -593,6 +593,9 @@ module Jekyll
       end
 
       def generate_details?
+        if !config['details_link'] then
+          return false
+        end 
         site.layouts.key?(File.basename(config['details_layout'], '.html'))
       end
 

--- a/lib/jekyll/scholar/utilities.rb
+++ b/lib/jekyll/scholar/utilities.rb
@@ -592,10 +592,14 @@ module Jekyll
         e
       end
 
-      def generate_details?
+      def generate_details_link?
         if !config['details_link'] then
           return false
-        end 
+        end
+        return true
+      end 
+#
+      def generate_details?
         site.layouts.key?(File.basename(config['details_layout'], '.html'))
       end
 


### PR DESCRIPTION
Issue #325. If details_link is not configured then do not insert the default tag.